### PR TITLE
Removing static constraints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,3 @@ tokio = { version = "1", features = ["macros", "rt", "sync", "time"]}
 
 [dev-dependencies]
 lazy_static = "1.4.0"
-mockall = "0.11.4"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -28,7 +28,7 @@ pub trait Cacheable<K, V> {
     fn get<Q>(&self, key: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq + ?Sized + 'static;
+        Q: Hash + Eq + ?Sized;
 
     fn purge_expired(&mut self);
 }
@@ -62,22 +62,26 @@ where
 pub(crate) mod test_helpers {
     use std::{borrow::Borrow, hash::Hash, time::Instant};
 
-    use mockall::mock;
-
     use super::Cacheable;
 
-    mock! {
-        pub Cache<K: 'static, V: 'static> {}
+    #[derive(Default)]
+    pub(crate) struct SpyCache {
+        pub purge_expired_called: bool,
+    }
 
-        impl<K , V> Cacheable<K, V> for Cache<K, V> {
-            fn purge_expired(&mut self) {}
+    impl<K, V> Cacheable<K, V> for SpyCache {
+        fn insert(&mut self, _key: K, _val: V, _expires_at: Instant) {}
 
-            fn get<Q>(&self, key: &Q) -> Option<&'static V>
-            where
-                K: Borrow<Q>,
-                Q: Hash + Eq + ?Sized + 'static, {}
+        fn get<Q>(&self, _key: &Q) -> Option<&V>
+        where
+            K: Borrow<Q>,
+            Q: Hash + Eq + ?Sized,
+        {
+            Default::default()
+        }
 
-            fn insert(&mut self, key: K, val: V, expires_at: Instant) {}
+        fn purge_expired(&mut self) {
+            self.purge_expired_called = true;
         }
     }
 }

--- a/src/purge_loop.rs
+++ b/src/purge_loop.rs
@@ -9,11 +9,12 @@ use crate::cache::Cacheable;
 pub fn start_purge_loop<C, K, V>(cache: Arc<RwLock<C>>, mut purge_interval: Interval)
 where
     C: Cacheable<K, V> + Send + Sync + 'static,
-    K: Eq + Hash + Send + Sync + 'static,
-    V: Send + Sync + 'static,
+    K: Eq + Hash + Send + Sync,
+    V: Send + Sync,
 {
     tokio::task::spawn(async move {
         loop {
+            // Note that the first tick is instantaneous.
             purge_interval.tick().await;
             cache.write().await.purge_expired();
         }
@@ -28,21 +29,22 @@ mod tests {
     use tokio::sync::RwLock;
     use tokio::time::{interval, sleep};
 
-    use crate::cache::test_helpers::MockCache;
+    use crate::cache::test_helpers::SpyCache;
     use crate::purge_loop::start_purge_loop;
 
     #[tokio::test]
     async fn when_the_purge_loop_runs_then_the_cache_deletes_expired_entries() {
         // Arrange
-        let mut cache = MockCache::<&str, &str>::new();
-        cache.expect_purge_expired().times(1);
-        let cache = Arc::new(RwLock::new(cache));
+        let cache = Arc::new(RwLock::new(SpyCache::default()));
 
         // Act
-        start_purge_loop(cache.clone(), interval(Duration::from_secs(10000)));
+        start_purge_loop::<SpyCache, String, String>(
+            cache.clone(),
+            interval(Duration::from_secs(10000)),
+        );
 
-        // Assert - expectation in mock
+        // Assert
         sleep(Duration::from_millis(1)).await;
-        cache.write().await.checkpoint();
+        assert!(cache.write().await.purge_expired_called);
     }
 }


### PR DESCRIPTION
# Situation
Previously, there were `` `static `` constraints on a few generics that were required to use `mockall`. These ended up being problematic when using this crate.

# Target
Improve usability of the crate.

# Proposal
Remove the excessive `` `static `` constraints. This will force the removal of `mockall`. Replace the mock with a manually-crafted spy.