### PR TITLE
Updating crate name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "ttl-cache"
+name = "ttl_cache_with_purging"
 authors = ["Will-Low <26700668+Will-Low@users.noreply.github.com>"]
 version = "0.1.0"
 edition = "2021"
 description = "A time-to-live (TTL) cache implementation with optional background purging for expired entries."
 readme = "README.md"
 homepage = "https://aembit.io/"
-repository = "https://github.com/Aembit/ttl-cache/"
+repository = "https://github.com/Aembit/ttl_cache_with_purging"
 license = "MIT OR Apache-2.0"
 keywords = ["ttl", "cache", "caching", "expire", "expiring"]
 categories = ["caching", "asynchronous"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ttl-cache
+# ttl_cache_with_purging
 
 A time-to-live (TTL) cache implementation with optional background purging
 for expired entries.
@@ -24,7 +24,7 @@ use std::{
 };
 
 use tokio::{sync::RwLock, time::interval};
-use ttl_cache::{cache::TtlCache, purging::start_periodic_purge};
+use ttl_cache_with_purging::{cache::TtlCache, purging::start_periodic_purge};
 
 const MIN_IN_SECS: u64 = 60;
 const HOUR_IN_SECS: u64 = 60 * MIN_IN_SECS;

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use tokio::{sync::RwLock, time::interval};
-use ttl_cache::{cache::TtlCache, purging::start_periodic_purge};
+use ttl_cache_with_purging::{cache::TtlCache, purging::start_periodic_purge};
 
 const MIN_IN_SECS: u64 = 60;
 const HOUR_IN_SECS: u64 = 60 * MIN_IN_SECS;


### PR DESCRIPTION
There is a crate called "ttl_cache". Ours current name is confusingly close. Updating the name for clarity.