### PR TITLE
Changing expiration type from `Instant` to `SystemTime`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ advantage of its write-preferring `RwLock`.
 ```rust
 use std::{
     sync::Arc,
-    time::{Duration, Instant},
+    time::{Duration, SystemTime},
 };
 
 use tokio::{sync::RwLock, time::interval};
@@ -40,7 +40,7 @@ async fn main() {
     let key = "key1";
     let val = "val1";
 
-    let expires_at = Instant::now()
+    let expires_at = SystemTime::now()
         .checked_add(Duration::from_secs(HOUR_IN_SECS))
         .unwrap();
     cache.write().await.insert(key, val, expires_at);

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,6 +1,6 @@
 use std::{
     sync::Arc,
-    time::{Duration, Instant},
+    time::{Duration, SystemTime},
 };
 
 use tokio::{sync::RwLock, time::interval};
@@ -20,7 +20,7 @@ async fn main() {
     let key = "key1";
     let val = "val1";
 
-    let expires_at = Instant::now()
+    let expires_at = SystemTime::now()
         .checked_add(Duration::from_secs(HOUR_IN_SECS))
         .unwrap();
     cache.write().await.insert(key, val, expires_at);


### PR DESCRIPTION
# Situation
Currently, the expiration time is captured as an `Instant`. This is fine for comparing against other instants. However, it doesn't work well when trying to work with other time types.

# Target
Change the expiration time to a type that can be more easily be used across various time types.

# Proposal
Move from using `Instant` to `SystemTime`.