### PR TITLE
Fixing fragile test

### DIFF
--- a/src/purging.rs
+++ b/src/purging.rs
@@ -40,7 +40,7 @@ mod tests {
         start_periodic_purge(cache.clone(), interval(Duration::from_secs(10000)));
 
         // Assert
-        sleep(Duration::from_millis(1)).await;
+        sleep(Duration::from_millis(10)).await;
         assert!(cache.write().await.purge_expired_called);
     }
 }


### PR DESCRIPTION
# Situation
Currently, we have a test that is temporarily sensitive. It may break when tests are being run.

# Target
Reduce fragility of the test.

# Proposal
Increase the sleep duration before checking the test condition.