### PR TITLE
Move from `SystemTime` to `Instant`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ttl_cache_with_purging"
 authors = ["Will-Low <26700668+Will-Low@users.noreply.github.com>"]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A time-to-live (TTL) cache implementation with optional background purging for expired entries."
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ advantage of its write-preferring `RwLock`.
 ## Example
 
 ```rust
-use std::{
-    sync::Arc,
-    time::{Duration, SystemTime},
-};
+use std::{sync::Arc, time::Duration};
 
-use tokio::{sync::RwLock, time::interval};
+use tokio::{
+    sync::RwLock,
+    time::{interval, Instant},
+};
 use ttl_cache_with_purging::{cache::TtlCache, purging::start_periodic_purge};
 
 const MIN_IN_SECS: u64 = 60;
@@ -40,7 +40,7 @@ async fn main() {
     let key = "key1";
     let val = "val1";
 
-    let expires_at = SystemTime::now()
+    let expires_at = Instant::now()
         .checked_add(Duration::from_secs(HOUR_IN_SECS))
         .unwrap();
     cache.write().await.insert(key, val, expires_at);

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,9 +1,9 @@
-use std::{
-    sync::Arc,
-    time::{Duration, SystemTime},
-};
+use std::{sync::Arc, time::Duration};
 
-use tokio::{sync::RwLock, time::interval};
+use tokio::{
+    sync::RwLock,
+    time::{interval, Instant},
+};
 use ttl_cache_with_purging::{cache::TtlCache, purging::start_periodic_purge};
 
 const MIN_IN_SECS: u64 = 60;
@@ -20,7 +20,7 @@ async fn main() {
     let key = "key1";
     let val = "val1";
 
-    let expires_at = SystemTime::now()
+    let expires_at = Instant::now()
         .checked_add(Duration::from_secs(HOUR_IN_SECS))
         .unwrap();
     cache.write().await.insert(key, val, expires_at);


### PR DESCRIPTION
# Situation
Currently, we use `SystemTime` for our expiration time. However, if the host system time is off or tampered with, it can cause the cache to purge when it shouldn't.

# Target
Ensure that our expiration time is not subject to host inaccuracies or tampering.

# Proposal
Move to using `Instant`, which does not reference the host system time.